### PR TITLE
feat(e2e): add logout flow test

### DIFF
--- a/qa/e2e/pages/DashboardPage.ts
+++ b/qa/e2e/pages/DashboardPage.ts
@@ -1,0 +1,108 @@
+import { Page, Locator } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Dashboard Page Object Model
+ * Handles all interactions with the dashboard page including logout functionality
+ * 
+ * Requires successful login to access dashboard features
+ * Provides logout functionality that redirects back to login page
+ */
+export class DashboardPage extends BasePage {
+  // Page elements - OrangeHRM specific selectors for dashboard and logout
+  readonly dashboardH6: Locator;
+  readonly userDropdown: Locator;
+  readonly logoutOption: Locator;
+  readonly profileImage: Locator;
+  readonly userMenu: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    
+    // Initialize locators with robust OrangeHRM-specific selectors
+    this.dashboardH6 = page.locator('h6.oxd-text--h6.oxd-topbar-header-breadcrumb-module, h6:has-text("Dashboard")');
+    
+    // User dropdown menu selectors (multiple fallbacks for robustness)
+    this.userDropdown = page.locator('.oxd-userdropdown-tab, .user-dropdown, .dropdown-toggle').first();
+    this.profileImage = page.locator('.oxd-userdropdown-img, .profile-img, img[alt*="profile"]').first();
+    this.userMenu = page.locator('.oxd-dropdown-menu, .dropdown-menu').first();
+    
+    // Logout option in the dropdown menu
+    this.logoutOption = page.locator('a:has-text("Logout"), .oxd-userdropdown-link:has-text("Logout")').first();
+  }
+
+  /**
+   * Navigate to the dashboard page
+   * Note: Usually reached after successful login
+   */
+  async goto(): Promise<void> {
+    await super.goto('/web/index.php/dashboard/index');
+    await this.waitForDashboardLoad();
+  }
+
+  /**
+   * Wait for dashboard to be fully loaded
+   */
+  async waitForDashboardLoad(): Promise<void> {
+    await this.page.waitForURL(/\/dashboard/i, { timeout: 15000 });
+    await this.expectVisible(this.dashboardH6, 'Dashboard heading should be visible');
+  }
+
+  /**
+   * Verify that we are on the dashboard page
+   */
+  async verifyDashboardLoaded(): Promise<void> {
+    await this.expectVisible(this.dashboardH6, 'Dashboard heading should be visible');
+    await this.expectVisible(this.userDropdown, 'User dropdown should be visible');
+  }
+
+  /**
+   * Perform logout operation
+   * Clicks user dropdown and selects logout option
+   */
+  async logout(): Promise<void> {
+    // Wait for dashboard to be fully loaded first
+    await this.waitForDashboardLoad();
+
+    // Click on user dropdown to open the menu
+    await this.userDropdown.click();
+
+    // Wait for dropdown menu to be visible
+    await this.expectVisible(this.logoutOption, 'Logout option should be visible in dropdown');
+
+    // Click logout option
+    await this.logoutOption.click();
+
+    // Wait for navigation to login page
+    await this.page.waitForURL(/\/auth\/login/i, { timeout: 15000 });
+  }
+
+  /**
+   * Verify logout was successful by checking we're back on login page
+   */
+  async verifyLogoutSuccessful(): Promise<void> {
+    // Verify URL contains login path
+    await this.page.waitForURL(/\/auth\/login/i, { timeout: 15000 });
+    
+    // Verify login page elements are visible
+    const usernameInput = this.page.locator('input[name="username"], input[placeholder="Username"]');
+    const passwordInput = this.page.locator('input[name="password"], input[placeholder="Password"]');
+    
+    await this.expectVisible(usernameInput, 'Username input should be visible after logout');
+    await this.expectVisible(passwordInput, 'Password input should be visible after logout');
+  }
+
+  /**
+   * Check if user dropdown menu is open
+   */
+  async isUserMenuOpen(): Promise<boolean> {
+    return await this.userMenu.isVisible();
+  }
+
+  /**
+   * Get the dashboard page title
+   */
+  async getDashboardTitle(): Promise<string> {
+    return await this.dashboardH6.textContent() || '';
+  }
+}

--- a/qa/e2e/tests/logout.spec.ts
+++ b/qa/e2e/tests/logout.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+import { LoginPage } from '../pages/LoginPage';
+import { DashboardPage } from '../pages/DashboardPage';
+
+test.describe('Logout Functionality', () => {
+  let loginPage: LoginPage;
+  let dashboardPage: DashboardPage;
+
+  test.beforeEach(async ({ page }) => {
+    loginPage = new LoginPage(page);
+    dashboardPage = new DashboardPage(page);
+    
+    // Navigate to login page and perform login before each test
+    await loginPage.goto();
+    await loginPage.verifyLoginPageLoaded();
+    await loginPage.loginWithEnvCredentials();
+    await loginPage.verifyDashboardVisible();
+  });
+
+  test('should logout and redirect to login page', async ({ page }) => {
+    // Verify we're on the dashboard page
+    await dashboardPage.verifyDashboardLoaded();
+    
+    // Perform logout
+    await dashboardPage.logout();
+    
+    // Verify logout was successful
+    await dashboardPage.verifyLogoutSuccessful();
+    
+    // Additional verification: check URL contains login path
+    expect(page.url()).toMatch(/\/auth\/login/);
+    
+    // Verify login page elements are visible after logout
+    await expect(page.locator('input[name="username"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+    await expect(page.getByRole('button', { name: /login/i })).toBeVisible();
+  });
+
+  test('should have user dropdown accessible on dashboard', async ({ page }) => {
+    // Verify we're on the dashboard page
+    await dashboardPage.verifyDashboardLoaded();
+    
+    // Verify user dropdown is visible
+    await expect(dashboardPage.userDropdown).toBeVisible();
+    
+    // Click dropdown to open menu
+    await dashboardPage.userDropdown.click();
+    
+    // Verify logout option is visible in the dropdown
+    await expect(dashboardPage.logoutOption).toBeVisible();
+  });
+
+  test('should maintain session until logout is clicked', async ({ page }) => {
+    // Verify we're on the dashboard page
+    await dashboardPage.verifyDashboardLoaded();
+    
+    // Navigate to different part of dashboard (refresh)
+    await page.reload();
+    
+    // Verify we're still logged in and on dashboard
+    await dashboardPage.verifyDashboardLoaded();
+    expect(page.url()).toMatch(/\/dashboard/);
+    
+    // Verify dashboard title is present
+    const dashboardTitle = await dashboardPage.getDashboardTitle();
+    expect(dashboardTitle.toLowerCase()).toContain('dashboard');
+  });
+
+  test('should complete full login-logout cycle', async ({ page }) => {
+    // Starting from already logged in state (from beforeEach)
+    await dashboardPage.verifyDashboardLoaded();
+    
+    // Perform logout
+    await dashboardPage.logout();
+    await dashboardPage.verifyLogoutSuccessful();
+    
+    // Verify we can login again after logout
+    await loginPage.verifyLoginPageLoaded();
+    await loginPage.loginWithEnvCredentials();
+    await loginPage.verifyDashboardVisible();
+    
+    // Verify we're back on dashboard
+    await dashboardPage.verifyDashboardLoaded();
+    expect(page.url()).toMatch(/\/dashboard/);
+  });
+});


### PR DESCRIPTION
# PR – E2E Test Automation (Playwright + TypeScript)

## Tipo
- [ ] feat
- [ ] fix
- [ ] chore
- [ ] docs
- [x] test

## Descrição
Implementa testes E2E completos para funcionalidade de logout.

Novos arquivos:
- qa/e2e/pages/DashboardPage.ts
- qa/e2e/tests/logout.spec.ts

Cobertura:
✅ Fluxo principal de logout
✅ Acessibilidade do dropdown do usuário
✅ Persistência de sessão até logout
✅ Ciclo completo login-logout-login

Todos os testes passaram localmente nos 3 browsers.

## Checklist
- [x] Rodei localmente `npm run validate:env`
- [x] Rodei `npm run test:e2e` e verifiquei o report
- [x] Não inclui arquivos fora de `qa/e2e/**` para testes
- [x] Este PR não altera nada relacionado a Supabase/Make.com/SQL/etc.
- [x] PR direcionado para `main` (branch protegida)

## Evidências (opcional)
- Link de relatório local/prints